### PR TITLE
use loaderOptionsPlugin to use webpack 2.1.0-beta.25

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,18 @@
 import {WebpackConfigWithMetadata, get} from '@easy-webpack/core'
 import * as path from 'path'
-import * as webpack from 'webpack'
 
 /**
  * Tslint loader support for *.ts files
  * See: https://github.com/wbuchwalter/tslint-loader
  */
-export = function tslint({options = undefined, exclude = null} = {}) {
+export = function tslint({exclude = null} = {}) {
   return function tslint(this: WebpackConfigWithMetadata): WebpackConfigWithMetadata {
     return {
       module: {
         rules: get(this, 'module.rules', []).concat([
           { test: /\.tsx?$/, loader: 'tslint-loader', enforce: 'pre', exclude: exclude || (this.metadata.root ? [path.join(this.metadata.root, 'node_modules')] : []) }
         ])
-      },
-      plugins: [
-        new webpack.LoaderOptionsPlugin({
-          options: {
-            tslint: options
-          }
-        })
-      ]
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import {WebpackConfigWithMetadata, get} from '@easy-webpack/core'
 import * as path from 'path'
+import * as webpack from 'webpack'
 
 /**
  * Tslint loader support for *.ts files
@@ -13,7 +14,13 @@ export = function tslint({options = undefined, exclude = null} = {}) {
           { test: /\.tsx?$/, loader: 'tslint-loader', enforce: 'pre', exclude: exclude || (this.metadata.root ? [path.join(this.metadata.root, 'node_modules')] : []) }
         ])
       },
-      tslint: options
+      plugins: [
+        new webpack.LoaderOptionsPlugin({
+          options: {
+            tslint: options
+          }
+        })
+      ]
     }
   }
 }


### PR DESCRIPTION
Webpack version: 2.1.0-beta.25

This PR fixes the validation issue for webpack beta 25.

Issue:
```javascript
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration has an unknown property 'tslint'. These properties are valid:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry, externals?, loader?, module?, name?, node?, output?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, stats?, target?, watch?, watchOptions? }
   For typos: please correct them.
   For loader options: webpack 2 no longer allows custom properties in configuration.
     Loaders should be updated to allow passing options via loader options in module.rules.
     Until loaders are updated one can use the LoaderOptionsPlugin to pass these options to the loader:
     plugins: {
       new webpack.LoaderOptionsPlugin({
         // test: /\.xxx$/, // may apply this only for some modules
         options: {
           tslint: ...
         }
       })
     }
```
